### PR TITLE
FIX type MIME Javascript in header http

### DIFF
--- a/js/listincsv.js.php
+++ b/js/listincsv.js.php
@@ -1,4 +1,53 @@
-/*<script type="text/javascript">*/
+<?php
+/* Copyright (C) 2005-2014  Laurent Destailleur <eldy@users.sourceforge.net>
+ * Copyright (C) 2005-2014  Regis Houssin       <regis.houssin@capnetworks.com>
+ * Copyright (C) 2015       Raphaël Doursenaud  <rdoursenaud@gpcsolutions.fr>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * or see http://www.gnu.org/
+ */
+
+/**
+ * \file		htdocs/listincsv/js/lib_head.js.php
+ * \brief		File that include javascript functions (included if option use_javascript activated)
+ * 				JQuery (providing object $) and JQuery-UI (providing $datepicker) libraries must be loaded before this file.
+ */
+
+//if (! defined('NOREQUIREUSER')) define('NOREQUIREUSER','1');	// Not disabled cause need to load personalized language
+//if (! defined('NOREQUIREDB'))   define('NOREQUIREDB','1');
+if (! defined('NOREQUIRESOC'))    define('NOREQUIRESOC','1');
+//if (! defined('NOREQUIRETRAN')) define('NOREQUIRETRAN','1');	// Not disabled cause need to do translations
+if (! defined('NOCSRFCHECK'))     define('NOCSRFCHECK',1);
+if (! defined('NOTOKENRENEWAL'))  define('NOTOKENRENEWAL',1);
+if (! defined('NOLOGIN'))         define('NOLOGIN',1);
+if (! defined('NOREQUIREMENU'))   define('NOREQUIREMENU',1);
+if (! defined('NOREQUIREHTML'))   define('NOREQUIREHTML',1);
+if (! defined('NOREQUIREAJAX'))   define('NOREQUIREAJAX','1');
+
+session_cache_limiter(FALSE);
+
+$res=0;
+if (! $res && file_exists("../../main.inc.php")) $res=@include_once '../../main.inc.php';       // to work if your module directory is into a subdir of root htdocs directory
+if (! $res && file_exists("../../../main.inc.php")) $res=@include_once '../../../main.inc.php'; // to work if your module directory is into a subdir of root htdocs directory
+
+// Define javascript type
+top_httphead('text/javascript; charset=UTF-8');
+// Important: Following code is to avoid page request by browser and PHP CPU at each Dolibarr page access.
+if (empty($dolibarr_nocache)) header('Cache-Control: max-age=3600, public, must-revalidate');
+else header('Cache-Control: no-cache');
+?>
+
 // Function found here : https://stackoverflow.com/questions/16078544/export-to-csv-using-jquery-and-html
 function exportTableToCSV($table, filename) {
 


### PR DESCRIPTION
FIX type MIME Javascript in header http :
- avoid to have this Error "reference Error  : objectifyForm not defined" in some restrictive Web server.