### PR TITLE
FIX 1.0 - some unwanted invisible nodes got included in the CSV cells

### DIFF
--- a/js/listincsv.js.php
+++ b/js/listincsv.js.php
@@ -48,11 +48,23 @@ if (empty($dolibarr_nocache)) header('Cache-Control: max-age=3600, public, must-
 else header('Cache-Control: no-cache');
 ?>
 
+/**
+ * Returns a clone of the jquery collection $elem with all invisible (display:none) elements removed
+ * @param $elem  A jQuery collection
+ * @returns cloned jQuery collection
+ */
+function stripInvisible($elem) {
+	// https://stackoverflow.com/a/28963556/11987795
+	var $clone = $elem.clone();
+	$('body').append($clone);
+	$clone.find('*:not(:visible)').remove();
+	$clone.remove();
+	return $clone;
+}
+
 // Function found here : https://stackoverflow.com/questions/16078544/export-to-csv-using-jquery-and-html
 function exportTableToCSV($table, filename) {
-
-	var $rows = $table.find('tr:has(th),tr:has(td)'),
-
+	var $rows = stripInvisible($table).find('tr:has(th),tr:has(td)'),
 	// Temporary delimiter characters unlikely to be typed by keyboard
 	// This is to avoid accidentally splitting the actual contents
 	tmpColDelim = String.fromCharCode(11), // vertical tab character


### PR DESCRIPTION
## Context
A client reported that he got "Aperçu pdfTéléchargement pdf" in some cells of the "ref" column of the CSV file exported from the order list.

## Analysis
The text nodes containing "Aperçu pdf" and "Téléchargement pdf" are sub-nodes of elements with display:none.

## Fix
This fix creates a temporary copy of the table prior to parsing the table cells, removes all invisible nodes from the copy, then passes it on to the existing algorithm.