### PR TITLE
FIX 1.2.3: checkbox fields are not exported → export them as "0" or "1"

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,10 +3,10 @@
 ## Unreleased
 
 ## 1.2
-
-- FIX : Suppression du dossier Box ainsi que tu fichier box *11-05-2021* - 1.2.2
-- FIX : $_SESSION devient newToken() *11-05-2021* - 1.2.1
-- NEW : Déplacement du code qui crée le boutton vert "CSV" pour utilisation dans des modules externes avec un contexte ajax *06-05-2021* - 1.2.0
+- FIX : Les champs de type "case à cocher" ne sont pas exportés - *17/05/2021* - 1.2.3
+- FIX : Suppression du dossier Box ainsi que tu fichier box *11/05/2021* - 1.2.2
+- FIX : $_SESSION devient newToken() *11/05/2021* - 1.2.1
+- NEW : Déplacement du code qui crée le boutton vert "CSV" pour utilisation dans des modules externes avec un contexte ajax *06/05/2021* - 1.2.0
 
 ## 1.1
-- NEW : Ajout d'une gestion de récupération des informations via un autre paramètre que l'action du formulaire le plus proche *06-05-2021* - 1.1.0
+- NEW : Ajout d'une gestion de récupération des informations via un autre paramètre que l'action du formulaire le plus proche *06/05/2021* - 1.1.0

--- a/core/modules/modListInCSV.class.php
+++ b/core/modules/modListInCSV.class.php
@@ -59,9 +59,7 @@ class modListInCSV extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module ListInCSV";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-
-		$this->version = '1.2.2';
-
+		$this->version = '1.2.3';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)

--- a/js/listincsv.js.php
+++ b/js/listincsv.js.php
@@ -98,6 +98,10 @@ function exportTableToCSV($table, filename) {
 				imgtitle = $col.find('img').attr('title');
 				if (imgtitle != undefined) text = imgtitle.trim();
 			}
+			// si checkbox, on met 1 ou 0 selon qu’elle est cochée ou non
+			else if (text === '' && $col[0].firstChild.nodeName === 'INPUT' && $col[0].firstChild.type === 'checkbox') {
+				text = $col[0].firstChild.checked ? "1" : "0";
+			}
 
 			return text.replace(/"/g, '""'); // escape double quotes
 


### PR DESCRIPTION
# FIX DA020382
Les champs de type "case à cocher" ne sont pas exportés ; ce fix les détecte et les exporte sous forme de "1" ou "0".