### PR TITLE
FIX 1.2.4: previous fix broke the module

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ## 1.2
+- FIX : La liste ne s'exporte plus - *20/05/2021* - 1.2.4
 - FIX : Les champs de type "case à cocher" ne sont pas exportés - *17/05/2021* - 1.2.3
 - FIX : Suppression du dossier Box ainsi que tu fichier box *11/05/2021* - 1.2.2
 - FIX : $_SESSION devient newToken() *11/05/2021* - 1.2.1

--- a/core/modules/modListInCSV.class.php
+++ b/core/modules/modListInCSV.class.php
@@ -59,7 +59,7 @@ class modListInCSV extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module ListInCSV";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.2.3';
+		$this->version = '1.2.4';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)

--- a/js/listincsv.js.php
+++ b/js/listincsv.js.php
@@ -83,6 +83,7 @@ function exportTableToCSV($table, filename) {
 			var $col = $(col);
 
 			var text = "";
+			let $colFirstChild = $col.children().first();
 			if ($col.find("span.linkobject:not(.hideobject)").length > 0) {
 				// Fix sur liste produit si conf MAIN_DIRECT_STATUS_UPDATE active
 				text = $col.find("span.linkobject:not(.hideobject)").children().first().attr('title').trim();
@@ -99,8 +100,11 @@ function exportTableToCSV($table, filename) {
 				if (imgtitle != undefined) text = imgtitle.trim();
 			}
 			// si checkbox, on met 1 ou 0 selon qu’elle est cochée ou non
-			else if (text === '' && $col[0].firstChild.nodeName === 'INPUT' && $col[0].firstChild.type === 'checkbox') {
-				text = $col[0].firstChild.checked ? "1" : "0";
+			else if (text === ''
+				&& $colFirstChild.length
+				&& $colFirstChild.prop('nodeName') === 'INPUT'
+				&& $colFirstChild.prop('type') === 'checkbox') {
+				text = $colFirstChild.prop('checked') ? "1" : "0";
 			}
 
 			return text.replace(/"/g, '""'); // escape double quotes


### PR DESCRIPTION
# FIX
Le fix précédent (export des checkbox) cassait le module car il accédait à des propriétés d’objets JS pas toujours définis.

Ce fix du fix utilise jQuery pour plus de cohérence avec le reste du module.