### PR TITLE
FIX 1.3: calling call_trigger on non-objects (e.g. GPAO list of MOs)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,14 +3,15 @@
 ## Unreleased
 
 ## 1.3
-- NEW : Déclenchement d'un trigger sur export d'un fichier avec listincsv *19-05-2021* 1.3.0
+- FIX: Appel de `call_trigger()` sur un non-objet - *08/10/2021* - 1.3.1
+- NEW: Déclenchement d'un trigger sur export d'un fichier avec listincsv - *19/05/2021* - 1.3.0
 
 ## 1.2
-- FIX : La liste ne s'exporte plus - *20/05/2021* - 1.2.4
-- FIX : Les champs de type "case à cocher" ne sont pas exportés - *17/05/2021* - 1.2.3
-- FIX : Suppression du dossier Box ainsi que tu fichier box *11/05/2021* - 1.2.2
-- FIX : $_SESSION devient newToken() *11/05/2021* - 1.2.1
-- NEW : Déplacement du code qui crée le boutton vert "CSV" pour utilisation dans des modules externes avec un contexte ajax *06/05/2021* - 1.2.0
+- FIX: La liste ne s'exporte plus - *20/05/2021* - 1.2.4
+- FIX: Les champs de type "case à cocher" ne sont pas exportés - *17/05/2021* - 1.2.3
+- FIX: Suppression du dossier Box ainsi que tu fichier box *11/05/2021* - 1.2.2
+- FIX: $_SESSION devient newToken() *11/05/2021* - 1.2.1
+- NEW: Déplacement du code qui crée le boutton vert "CSV" pour utilisation dans des modules externes avec un contexte ajax *06/05/2021* - 1.2.0
 
 ## 1.1
-- NEW : Ajout d'une gestion de récupération des informations via un autre paramètre que l'action du formulaire le plus proche *06/05/2021* - 1.1.0
+- NEW: Ajout d'une gestion de récupération des informations via un autre paramètre que l'action du formulaire le plus proche *06/05/2021* - 1.1.0

--- a/class/actions_listincsv.class.php
+++ b/class/actions_listincsv.class.php
@@ -63,7 +63,7 @@ class ActionsListInCSV
 
 		global $db, $user;
 
-		if(GETPOSTISSET('exportlistincsv', 'bool')) {
+		if(GETPOSTISSET('exportlistincsv', 'bool') && method_exists($object, 'call_trigger')) {
 			$object->call_trigger('LISTINCSV_EXPORT_FILE_'.strtoupper($object->element), $user);
 		}
 

--- a/core/modules/modListInCSV.class.php
+++ b/core/modules/modListInCSV.class.php
@@ -60,7 +60,7 @@ class modListInCSV extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "ListInCSV permet d'exporter en CSV une liste Dolibarr telle qu'elle apparaît à l'écran.";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.3.0';
+		$this->version = '1.3.1';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)


### PR DESCRIPTION
# FIX FATAL
If `$object` is not a CommonObject or an object that implements `call_trigger`, we should not attempt to call `call_trigger`.