### PR TITLE
Fix 1.3: cleanup js + bouton n'apparaît pas dans objets référents des produits

### DIFF
--- a/class/actions_listincsv.class.php
+++ b/class/actions_listincsv.class.php
@@ -80,7 +80,7 @@ class ActionsListInCSV
 	 */
 	function printCommonFooter($parameters, &$object, &$action, $hookmanager)
 	{
-		if (strpos($parameters['context'], 'list') !== false)
+		if (strpos($parameters['context'], 'list') !== false || preg_match('/\bproductstats(?!card)/', $parameters['context']))
 		{
 			global $langs, $user, $conf;
 			$langs->load('listincsv@listincsv');
@@ -112,92 +112,107 @@ class ActionsListInCSV
 				?>
 				<script type="text/javascript" language="javascript" src="<?php echo $pathtojs; ?>"></script>
 				<script type="text/javascript" language="javascript">
-
-				const listInCSVMain = function(varsFromPHP) {
-					console.info('listInCSVMain', varsFromPHP);
-					if (varsFromPHP.TContexts.includes('projecttasklist')) {
-						$('#id-right > form#searchFormList div.titre').first().append(varsFromPHP.downloadButton); // Il peut y avoir plusieurs titre dans la page
-					} else {
-						const divTitre = $('div.fiche div.titre').first();
-						if(typeof divTitre.val() !== 'undefined') {
-							divTitre.append(varsFromPHP.downloadButton); // Il peut y avoir plusieurs titre dans la page
+					/**
+					 * @param {string}   varsFromPHP.downloadButton  Bouton ListInCSV
+					 * @param {string[]} varsFromPHP.TContexts       Liste des contextes de hooks
+					 * @param {Number}   varsFromPHP.socid           ID du tiers si applicable, 0 sinon
+					 * @param {string[]} varsFromPHP.langs           Traductions utilisées par js
+					 * @param {Object}   varsFromPHP.conf            Confs utilisées par js
+					 */
+					const listInCSVMain = function (varsFromPHP) {
+						// Ajout du bouton ListInCSV
+						if (varsFromPHP.TContexts.includes('projecttasklist')) {
+							// Cas particulier de la liste des tâches sur un projet
+							// `first()` parce qu'il peut y avoir plusieurs titres sur la page.
+							$('#id-right > form#searchFormList div.titre').first().append(varsFromPHP.downloadButton);
+						} else if (varsFromPHP.TContexts.some(ctx => ctx.match(/^productstats/))) {
+							// Cas particulier des objets référents sur un produit
+							$('form[name="search_form"] table.table-fiche-title div.titre').first().append(varsFromPHP.downloadButton);
 						} else {
-							$('[name="button_search"]').after(varsFromPHP.downloadButton); // S'il n'y a pas de titre, on l'ajoute à côté de la loupe c'est mieux que rien...
-						}
-					}
-					$(document).on('click', ".export", function(event) {
-						// Récupération des données du formulaire de filtre et transformation en objet
-						const $form = $('div.fiche form').first(); // Les formulaire de liste n'ont pas tous les même name
-						const data = objectifyForm($form.serializeArray());
-
-						// Pas de limite, on veut télécharger la liste totale
-						data.limit = 10000000;
-						data.socid = varsFromPHP.socid;
-						data.exportlistincsv=1;
-
-						const $self = $(this);
-						const $dialogPopup = $('#dialogforpopup');
-
-						$dialogPopup.html(varsFromPHP.langs['FileGenerationInProgress']);
-						$dialogPopup.dialog({
-							open : function(event, ui) {
-								var used_url = $form.attr('data-listincsv-url');
-								if(typeof used_url === 'undefined') used_url = $form.attr('action');
-
-								// Envoi de la requête HTTP en mode synchrone
-								$.ajax({
-									url: used_url,
-									type: $form.attr('method'),
-									data: data,
-									async: false
-								}).done(function(html) {
-									// Récupération de la table html qui nous intéresse
-									var $table = $(html).find('table.liste');
-                                    let search = $table.find('tr.liste_titre_filter');
-									// Nettoyage de la table avant conversion en CSV
-
-									// Suppression des filtres de la liste
-									$table.find('tr.liste_titre_filter').remove(); // >= 6.0
-									$table.find('tr:has(td.liste_titre)').remove(); // < 6.0
-
-									// Suppression de la dernière colonne qui contient seulement les loupes des filtres
-                                    $table.find('th:last-child, td:last-child').each(function(index){
-                                        $(this).find('dl').remove();
-                                       if($(search).length > 0 && $(this).closest('table').hasClass('liste')) $(this).remove(); //Dans les listes ne contenant pas de recherche, il ne faut pas supprimer la derniere colonne
-                                    });
-
-									// Suppression de la ligne TOTAL en pied de tableau
-									if (varsFromPHP.conf['LISTINCSV_DONT_REMOVE_TOTAL']) {
-										$table.find('tr.liste_total').remove();
-									}
-
-									//Suppression des espaces pour les nombres
-									if (varsFromPHP.conf['LISTINCSV_DELETESPACEFROMNUMBER']) {
-										$table.find('td').each(function(e) {
-											let nbWthtSpace = $(this).text().replace(/ /g,'').replace(/\xa0/g,'');
-											let commaToPoint = nbWthtSpace.replace(',', '.');
-											if($.isNumeric(commaToPoint)) $(this).html(nbWthtSpace);
-										});
-									}
-
-									// Remplacement des sous-table par leur valeur text(), notamment pour la ref dans les listes de propales, factures...
-									$table.find('td > table').map(function(i, cell) {
-										$cell = $(cell);
-										$cell.html($cell.text());
-									});
-
-									// Transformation de la table liste en CSV + téléchargement
-									var args = [$table, 'export.csv'];
-									exportTableToCSV.apply($self, args);
-
-									$('#dialogforpopup').dialog('close');
-								});
+							const divTitre = $('div.fiche div.titre').first();
+							if (typeof divTitre.val() !== 'undefined') {
+								// Cas général
+								divTitre.append(varsFromPHP.downloadButton);
+							} else {
+								// S'il n'y a pas de titre, on l'ajoute à côté de la loupe c'est mieux que rien...
+								$('[name="button_search"]').after(varsFromPHP.downloadButton);
 							}
-						});
-					});
-				};
+						}
 
-				$(document).ready(() => listInCSVMain(<?php echo json_encode($varsForJs) ?>));
+						// Action du clic sur le bouton
+						$(document).on('click', ".export", function (event) {
+							// Récupération des données du formulaire de filtre et transformation en objet
+							const $form = $('div.fiche form').first(); // Les formulaire de liste n'ont pas tous les même name
+							const data = objectifyForm($form.serializeArray());
+
+							// Pas de limite, on veut télécharger la liste totale
+							data.limit = 10000000;
+							data.socid = varsFromPHP.socid;
+							data.exportlistincsv = 1;
+
+							const $self = $(this);
+							const $dialogPopup = $('#dialogforpopup');
+
+							$dialogPopup.html(varsFromPHP.langs['FileGenerationInProgress']);
+							$dialogPopup.dialog({
+								open: function (event, ui) {
+									var used_url = $form.attr('data-listincsv-url');
+									if (typeof used_url === 'undefined') used_url = $form.attr('action');
+
+									// Envoi de la requête HTTP en mode synchrone
+									$.ajax({
+										url: used_url,
+										type: $form.attr('method'),
+										data: data,
+										async: false
+									}).done(function (html) {
+										// Récupération de la table html qui nous intéresse
+										var $table = $(html).find('table.liste');
+										let search = $table.find('tr.liste_titre_filter');
+										// Nettoyage de la table avant conversion en CSV
+
+										// Suppression des filtres de la liste
+										$table.find('tr.liste_titre_filter').remove(); // >= 6.0
+										$table.find('tr:has(td.liste_titre)').remove(); // < 6.0
+
+										// Suppression de la dernière colonne qui contient seulement les loupes des filtres
+										$table.find('th:last-child, td:last-child').each(function (index) {
+											$(this).find('dl').remove();
+											if ($(search).length > 0 && $(this).closest('table').hasClass('liste')) $(this).remove(); //Dans les listes ne contenant pas de recherche, il ne faut pas supprimer la derniere colonne
+										});
+
+										// Suppression de la ligne TOTAL en pied de tableau
+										if (varsFromPHP.conf['LISTINCSV_DONT_REMOVE_TOTAL']) {
+											$table.find('tr.liste_total').remove();
+										}
+
+										//Suppression des espaces pour les nombres
+										if (varsFromPHP.conf['LISTINCSV_DELETESPACEFROMNUMBER']) {
+											$table.find('td').each(function (e) {
+												let nbWthtSpace = $(this).text().replace(/ /g, '').replace(/\xa0/g, '');
+												let commaToPoint = nbWthtSpace.replace(',', '.');
+												if ($.isNumeric(commaToPoint)) $(this).html(nbWthtSpace);
+											});
+										}
+
+										// Remplacement des sous-table par leur valeur text(), notamment pour la ref dans les listes de propales, factures...
+										$table.find('td > table').map(function (i, cell) {
+											$cell = $(cell);
+											$cell.html($cell.text());
+										});
+
+										// Transformation de la table liste en CSV + téléchargement
+										var args = [$table, 'export.csv'];
+										exportTableToCSV.apply($self, args);
+
+										$('#dialogforpopup').dialog('close');
+									});
+								}
+							});
+						});
+					};
+
+					$(document).ready(() => listInCSVMain(<?php echo json_encode($varsForJs) ?>));
 				</script>
 				<?php
 			} // End Rights test

--- a/js/listincsv.js.php
+++ b/js/listincsv.js.php
@@ -19,8 +19,8 @@
  */
 
 /**
- * \file		htdocs/listincsv/js/lib_head.js.php
- * \brief		File that include javascript functions (included if option use_javascript activated)
+ * \file		listincsv/js/listincsv.js.php
+ * \brief		Functions for the Dolibarr module ListInCSV
  * 				JQuery (providing object $) and JQuery-UI (providing $datepicker) libraries must be loaded before this file.
  */
 


### PR DESCRIPTION
Cette PR inclut un début de standardisation du JS (pour limiter le mélange php/js et faciliter la lecture) + des commentaires.

À relire avec l'[option whitespace](https://github.com/ATM-Consulting/dolibarr_module_listincsv/pull/48/files?diff=split&w=1).